### PR TITLE
feat(battleships): added winner name display and added rematch logic and settings screen for in-game leaving/surrender

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">

--- a/app/src/main/java/com/example/gamehub/MainActivity.kt
+++ b/app/src/main/java/com/example/gamehub/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.example.gamehub
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.padding
@@ -11,17 +12,28 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.*
 import androidx.navigation.navArgument
 import com.example.gamehub.navigation.NavRoutes
-import com.example.gamehub.ui.*                                 // LobbyMenuScreen, HostLobbyScreen, GuestGameScreen, MainMenu, GamesListScreen, SettingsScreen, TestSensorsScreen
+import com.example.gamehub.ui.*
 import com.example.gamehub.features.battleships.ui.BattleshipsScreen
 import com.example.gamehub.features.ohpardon.ui.OhPardonScreen
 import com.example.gamehub.features.spy.ui.SpyScreen
 import com.example.gamehub.features.jorisjump.ui.JorisJumpScreen
 import com.example.gamehub.features.screamosaur.ui.ScreamosaurScreen
+import com.google.firebase.auth.FirebaseAuth
 
 class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // ✅ Anonymous sign-in to fix Firestore permission errors
+        FirebaseAuth.getInstance().signInAnonymously()
+            .addOnSuccessListener {
+                Log.d("Auth", "Signed in anonymously: ${it.user?.uid}")
+            }
+            .addOnFailureListener {
+                Log.e("Auth", "Anonymous sign-in failed", it)
+            }
+
         setContent {
             GameHubApp()
         }
@@ -39,23 +51,21 @@ fun GameHubApp() {
             startDestination = NavRoutes.MAIN_MENU,
             modifier = Modifier.padding(innerPadding)
         ) {
-            // 1) Main menu / sensor tests
+            // Screens
             composable(NavRoutes.MAIN_MENU)    { MainMenu(navController) }
             composable(NavRoutes.GAMES_LIST)   { GamesListScreen(navController) }
             composable(NavRoutes.SETTINGS)     { SettingsScreen() }
             composable(NavRoutes.TEST_SENSORS) { TestSensorsScreen(navController) }
 
-            // 2) Lobby flow
-            composable(
-                NavRoutes.LOBBY_MENU,
+            // Lobby flow
+            composable(NavRoutes.LOBBY_MENU,
                 arguments = listOf(navArgument("gameId") { type = NavType.StringType })
             ) { back ->
                 val gameId = back.arguments!!.getString("gameId")!!
                 LobbyMenuScreen(navController, gameId)
             }
 
-            composable(
-                NavRoutes.HOST_LOBBY,
+            composable(NavRoutes.HOST_LOBBY,
                 arguments = listOf(
                     navArgument("gameId") { type = NavType.StringType },
                     navArgument("code")   { type = NavType.StringType }
@@ -66,8 +76,7 @@ fun GameHubApp() {
                 HostLobbyScreen(navController, gameId, code)
             }
 
-            composable(
-                NavRoutes.GUEST_GAME,
+            composable(NavRoutes.GUEST_GAME,
                 arguments = listOf(
                     navArgument("gameId")   { type = NavType.StringType },
                     navArgument("code")     { type = NavType.StringType },
@@ -80,9 +89,8 @@ fun GameHubApp() {
                 GuestGameScreen(navController, gameId, code, userName)
             }
 
-            // 3) After “Start Game” you land in the real game screen
-            composable(
-                NavRoutes.BATTLESHIPS_GAME,
+            // Multiplayer game screens
+            composable(NavRoutes.BATTLESHIPS_GAME,
                 arguments = listOf(
                     navArgument("code")     { type = NavType.StringType },
                     navArgument("userName") { type = NavType.StringType }
@@ -93,8 +101,7 @@ fun GameHubApp() {
                 BattleshipsScreen(navController, code, userName)
             }
 
-            composable(
-                NavRoutes.OHPARDON_GAME,
+            composable(NavRoutes.OHPARDON_GAME,
                 arguments = listOf(
                     navArgument("code")     { type = NavType.StringType },
                     navArgument("userName") { type = NavType.StringType }
@@ -105,10 +112,10 @@ fun GameHubApp() {
                 OhPardonScreen(navController, code, userName)
             }
 
-            // 4) Local single-player games
-            composable(NavRoutes.SPY_GAME)        { SpyScreen() }
-            composable(NavRoutes.JORISJUMP_GAME)  { JorisJumpScreen() }
-            composable(NavRoutes.SCREAMOSAUR_GAME){ ScreamosaurScreen() }
+            // Local games
+            composable(NavRoutes.SPY_GAME)         { SpyScreen() }
+            composable(NavRoutes.JORISJUMP_GAME)   { JorisJumpScreen() }
+            composable(NavRoutes.SCREAMOSAUR_GAME) { ScreamosaurScreen() }
         }
     }
 }

--- a/app/src/main/java/com/example/gamehub/features/Battleships/ui/BattleshipsScreen.kt
+++ b/app/src/main/java/com/example/gamehub/features/Battleships/ui/BattleshipsScreen.kt
@@ -1,33 +1,185 @@
 package com.example.gamehub.features.battleships.ui
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import com.example.gamehub.lobby.FirestoreSession
+import com.example.gamehub.lobby.LobbyService
+import com.example.gamehub.lobby.codec.BattleshipsCodec
+import com.example.gamehub.lobby.codec.BattleshipsState
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BattleshipsScreen(
     navController: NavController,
     code: String,
     userName: String
 ) {
-    Scaffold { padding ->
-        Column(
-            Modifier
-                .fillMaxSize()
-                .padding(padding)
-                .padding(16.dp)
-        ) {
-            Text(
-                text = "🐋 Battleships started!",
-                style = MaterialTheme.typography.headlineSmall
-            )
-            Spacer(Modifier.height(8.dp))
-            Text("Room code: $code", style = MaterialTheme.typography.bodyLarge)
-            Spacer(Modifier.height(8.dp))
-            Text("You are: $userName", style = MaterialTheme.typography.bodyLarge)
+    val playerUid = Firebase.auth.uid ?: return
+    val db = Firebase.firestore
+    val session = remember { FirestoreSession(code, BattleshipsCodec) }
+    val scope = rememberCoroutineScope()
+
+    var gameState by remember { mutableStateOf<BattleshipsState?>(null) }
+    var showSettings by remember { mutableStateOf(false) }
+    var gameEnded by remember { mutableStateOf(false) }
+    var resultText by remember { mutableStateOf("") }
+    var rematchVotes by remember { mutableStateOf(0) }
+    var totalPlayers by remember { mutableStateOf(2) }
+    var players by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
+    var resetAttempted by remember { mutableStateOf(false) }
+
+    // Load player names
+    LaunchedEffect(code) {
+        db.collection("rooms").document(code)
+            .addSnapshotListener { snap, _ ->
+                val list = snap?.get("players") as? List<Map<String, Any>> ?: return@addSnapshotListener
+                players = list.associate {
+                    val uid = it["uid"] as? String ?: ""
+                    val name = it["name"] as? String ?: ""
+                    uid to name
+                }
+            }
+    }
+
+    // Watch game state
+    LaunchedEffect(Unit) {
+        session.stateFlow.collect { state ->
+            gameState = state
         }
+    }
+
+    // Watch status & rematch state
+    LaunchedEffect(Unit) {
+        db.collection("rooms").document(code)
+            .addSnapshotListener { snap, _ ->
+                if (snap != null && snap.exists()) {
+                    val status = snap.getString("status")
+                    val gameId = snap.getString("gameId") ?: return@addSnapshotListener
+                    val playersList = snap.get("players") as? List<Map<String, Any>> ?: return@addSnapshotListener
+                    val uids = playersList.mapNotNull { it["uid"] as? String }
+                    val votes = snap.get("rematchVotes") as? Map<String, Boolean> ?: return@addSnapshotListener
+
+                    rematchVotes = votes.count { it.value }
+                    totalPlayers = uids.size
+
+                    if (status == "ended") {
+                        val result = snap.get("gameState.$gameId.gameResult") as? Map<*, *>
+                        val winnerUid = result?.get("winner") as? String ?: "Unknown"
+                        val reason = result?.get("reason") as? String ?: "unknown reason"
+                        val winnerName = players[winnerUid] ?: winnerUid
+                        resultText = "🏆 $winnerName wins by $reason"
+                        gameEnded = true
+                    }
+
+                    if (status == "ended" && votes.all { it.value } && !resetAttempted) {
+                        resetAttempted = true
+                        scope.launch {
+                            LobbyService.resetGameIfRematchReady(code, gameId, uids)
+                        }
+                    }
+
+                    if (status == "playing" && resetAttempted) {
+                        resetAttempted = false
+                        gameEnded = false
+                    }
+                }
+            }
+    }
+
+    // Main UI
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("🐋 Battleships") },
+                actions = {
+                    IconButton(onClick = { showSettings = true }) {
+                        Icon(Icons.Default.Settings, contentDescription = "Settings")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(Modifier.padding(padding).padding(16.dp)) {
+            gameState?.let { state ->
+                val currentPlayerName = players[state.currentTurn] ?: state.currentTurn
+                Text("Current turn: $currentPlayerName")
+                Spacer(Modifier.height(8.dp))
+                Text("Moves: ${state.moves.joinToString()}")
+            } ?: Text("Waiting for game state...")
+        }
+    }
+
+    // Game Settings Dialog
+    if (showSettings) {
+        AlertDialog(
+            onDismissRequest = { showSettings = false },
+            title = { Text("Game Settings") },
+            confirmButton = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Button(onClick = {
+                        scope.launch {
+                            LobbyService.surrender(code, "battleships", playerUid)
+                        }
+                        showSettings = false
+                    }) {
+                        Text("Surrender")
+                    }
+
+                    Button(onClick = {
+                        scope.launch {
+                            LobbyService.deleteRoom(code)
+                            navController.popBackStack()
+                        }
+                    }) {
+                        Text("Leave Game")
+                    }
+
+                    OutlinedButton(onClick = { showSettings = false }) {
+                        Text("Cancel")
+                    }
+                }
+            }
+        )
+    }
+
+    // Game Over Dialog
+    if (gameEnded) {
+        AlertDialog(
+            onDismissRequest = {},
+            title = { Text("Game Over") },
+            text = {
+                Column {
+                    Text(resultText)
+                    Spacer(Modifier.height(8.dp))
+                    Text("Rematch votes: $rematchVotes / $totalPlayers")
+                }
+            },
+            confirmButton = {
+                Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Button(onClick = {
+                        scope.launch {
+                            LobbyService.voteRematch(code, playerUid)
+                        }
+                    }) { Text("Rematch") }
+
+                    Button(onClick = {
+                        scope.launch {
+                            LobbyService.deleteRoom(code)
+                            navController.popBackStack()
+                        }
+                    }) { Text("Leave Game") }
+                }
+            }
+        )
     }
 }

--- a/app/src/main/java/com/example/gamehub/lobby/LobbyService.kt
+++ b/app/src/main/java/com/example/gamehub/lobby/LobbyService.kt
@@ -8,77 +8,55 @@ import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.tasks.await
-import java.util.UUID
 import kotlinx.coroutines.channels.awaitClose
+import java.util.UUID
 
 object LobbyService {
     private val firestore = FirebaseFirestore.getInstance()
-    private val rooms     = firestore.collection("rooms")
-    private val auth      = Firebase.auth
+    private val rooms = firestore.collection("rooms")
+    private val auth = Firebase.auth
 
-    /**
-     * Hosts a new room.
-     * @param gameId    the id of the game (“battleships”, “ohpardon”, …)
-     * @param roomName  the human-friendly room name (required)
-     * @param hostName  the display name of the host (required)
-     * @param password  optional raw password; will be hashed with .hashCode()
-     * @return the newly created room’s document ID (the join code)
-     */
     suspend fun host(
         gameId: String,
         roomName: String,
         hostName: String,
         password: String?
     ): String {
-        val hostUid = auth.currentUser?.uid
-            ?: throw IllegalStateException("Must be signed in to host")
+        val hostUid = auth.currentUser?.uid ?: throw IllegalStateException("Must be signed in to host")
+        val code = UUID.randomUUID().toString().replace("-", "").take(6).uppercase()
 
-        // 6-char uppercase join code
-        val code = UUID.randomUUID()
-            .toString()
-            .replace("-", "")
-            .take(6)
-            .uppercase()
-
-        // Decide maxPlayers based on the game:
         val maxPlayers = when (gameId) {
             "battleships" -> 2
-            "ohpardon"    -> 4
-            else          -> 4
+            "ohpardon" -> 4
+            else -> 4
         }
 
-        // Build our Room map (no nested serverTimestamp in arrays!)
-        val roomData = mapOf<String, Any?>(
-            "gameId"     to gameId,
-            "name"       to roomName,
-            "hostUid"    to hostUid,
-            "hostName"   to hostName,
-            "password"   to password?.hashCode(),
-            "maxPlayers" to maxPlayers,
-            "status"     to "waiting",
-            "players"    to listOf(
-                mapOf(
-                    "uid"  to hostUid,
-                    "name" to hostName
-                )
-            ),
-            "createdAt"  to FieldValue.serverTimestamp()
+        val initialGameState = mapOf(
+            gameId to mapOf(
+                "gameResult" to null
+            )
         )
 
-        rooms.document(code)
-            .set(roomData)
-            .await()
+        val roomData = mapOf<String, Any?>(
+            "gameId" to gameId,
+            "name" to roomName,
+            "hostUid" to hostUid,
+            "hostName" to hostName,
+            "password" to password?.hashCode(),
+            "maxPlayers" to maxPlayers,
+            "status" to "waiting",
+            "players" to listOf(
+                mapOf("uid" to hostUid, "name" to hostName)
+            ),
+            "gameState" to initialGameState,
+            "rematchVotes" to emptyMap<String, Boolean>(),
+            "createdAt" to FieldValue.serverTimestamp()
+        )
 
+        rooms.document(code).set(roomData).await()
         return code
     }
 
-    /**
-     * Attempts to join an existing room.
-     * @param code      the 6-char room code
-     * @param userName  the display name of the joining player (required)
-     * @param password  the raw room password (if any)
-     * @return the gameId if joined; null if room not found, password mismatch, or full.
-     */
     suspend fun join(
         code: String,
         userName: String,
@@ -88,33 +66,19 @@ object LobbyService {
         val snap = rooms.document(code).get().await()
         if (!snap.exists()) return null
 
-        // 1️⃣ Password check
         val expectedHash = snap.getLong("password")?.toInt()
-        if (expectedHash != null && expectedHash != password?.hashCode()) {
-            return null
-        }
+        if (expectedHash != null && expectedHash != password?.hashCode()) return null
 
-        // 2️⃣ Capacity check
-        val maxPlayers     = snap.getLong("maxPlayers")?.toInt() ?: return null
+        val maxPlayers = snap.getLong("maxPlayers")?.toInt() ?: return null
         val currentPlayers = (snap.get("players") as? List<*>)?.size ?: 0
         if (currentPlayers >= maxPlayers) return null
 
-        // 3️⃣ Add this player to the array
-        val playerData = mapOf(
-            "uid"  to user.uid,
-            "name" to userName
-        )
-        rooms.document(code)
-            .update("players", FieldValue.arrayUnion(playerData))
-            .await()
+        val playerData = mapOf("uid" to user.uid, "name" to userName)
+        rooms.document(code).update("players", FieldValue.arrayUnion(playerData)).await()
 
-        // 4️⃣ Return gameId so the UI can navigate
         return snap.getString("gameId")
     }
 
-    /**
-     * Streams the list of *waiting* rooms for a given gameId.
-     */
     fun publicRoomsFlow(gameId: String): Flow<List<RoomSummary>> = callbackFlow {
         val registration = rooms
             .whereEqualTo("gameId", gameId)
@@ -126,23 +90,95 @@ object LobbyService {
                     return@addSnapshotListener
                 }
                 val list = qs!!.documents.mapNotNull { doc ->
-                    val name    = doc.getString("name") ?: return@mapNotNull null
-                    val host    = doc.getString("hostName") ?: "?"
+                    val name = doc.getString("name") ?: return@mapNotNull null
+                    val host = doc.getString("hostName") ?: "?"
                     val players = (doc.get("players") as? List<*>)?.size ?: 0
-                    val maxP    = doc.getLong("maxPlayers")?.toInt() ?: 0
-                    val locked  = doc.getLong("password") != null
-                    RoomSummary(
-                        code           = doc.id,
-                        name           = name,
-                        hostName       = host,
-                        currentPlayers = players,
-                        maxPlayers     = maxP,
-                        hasPassword    = locked
-                    )
+                    val maxP = doc.getLong("maxPlayers")?.toInt() ?: 0
+                    val locked = doc.getLong("password") != null
+                    RoomSummary(doc.id, name, host, players, maxP, locked)
                 }
                 trySend(list)
             }
         awaitClose { registration.remove() }
+    }
+
+    suspend fun surrender(roomCode: String, gameId: String, surrenderingUid: String) {
+        val snap = rooms.document(roomCode).get().await()
+        val players = snap.get("players") as? List<Map<String, Any>> ?: return
+
+        val opponent = players.firstOrNull { it["uid"] != surrenderingUid }?.get("uid") as? String ?: return
+
+        val rematchVotes = players.associate {
+            val uid = it["uid"] as? String ?: ""
+            uid to false
+        }
+
+        rooms.document(roomCode).update(
+            mapOf(
+                "status" to "ended",
+                "gameState.$gameId.gameResult" to mapOf(
+                    "winner" to opponent,
+                    "loser" to surrenderingUid,
+                    "reason" to "surrender"
+                ),
+                "rematchVotes" to rematchVotes
+            )
+        ).await()
+    }
+
+    suspend fun voteRematch(roomCode: String, playerUid: String) {
+        if (playerUid.isBlank()) return
+        rooms.document(roomCode).update("rematchVotes.$playerUid", true).await()
+    }
+
+    suspend fun resetGameIfRematchReady(roomCode: String, gameId: String, playerUids: List<String>) {
+        val snap = rooms.document(roomCode).get().await()
+        val votes = snap.get("rematchVotes") as? Map<String, Boolean> ?: emptyMap()
+
+        // Make sure everyone voted rematch
+        if (playerUids.all { votes[it] == true }) {
+            val playersList = snap.get("players") as? List<Map<String, Any>> ?: return
+            val firstPlayerUid = playersList.firstOrNull()?.get("uid") as? String ?: return
+            resetGame(roomCode, gameId, playersList, firstPlayerUid)
+        }
+    }
+
+    private suspend fun resetGame(
+        roomCode: String,
+        gameId: String,
+        players: List<Map<String, Any>>,
+        startingPlayerUid: String
+    ) {
+        val resetState = when (gameId) {
+            "battleships" -> mapOf(
+                "currentTurn" to startingPlayerUid,
+                "moves" to emptyList<String>(),
+                "gameResult" to null
+            )
+            "ohpardon" -> mapOf(
+                "currentPlayer" to startingPlayerUid,
+                "scores" to emptyMap<String, Int>(),
+                "gameResult" to null
+            )
+            else -> emptyMap()
+        }
+
+        val resetVotes = players.associate {
+            val uid = it["uid"] as? String ?: ""
+            uid to false
+        }
+
+        rooms.document(roomCode).update(
+            mapOf(
+                "status" to "playing",
+                "rematchVotes" to resetVotes,
+                "gameState.$gameId" to resetState
+            )
+        ).await()
+    }
+
+    suspend fun deleteRoom(roomCode: String) {
+        rooms.document(roomCode).delete().await()
     }
 
     data class RoomSummary(

--- a/app/src/main/java/com/example/gamehub/lobby/codecs/BattleshipsCodec.kt
+++ b/app/src/main/java/com/example/gamehub/lobby/codecs/BattleshipsCodec.kt
@@ -1,0 +1,40 @@
+package com.example.gamehub.lobby.codec
+
+import com.example.gamehub.lobby.GameCodec
+import com.google.firebase.firestore.FieldValue
+
+// Top-level data classes
+data class BattleshipsMove(val position: String, val playerUid: String)
+
+data class BattleshipsState(
+    val currentTurn: String,
+    val moves: List<String>,
+    val gameResult: GameResult?
+)
+
+data class GameResult(val winner: String, val loser: String, val reason: String)
+
+// Codec object for encoding/decoding only
+object BattleshipsCodec : GameCodec<BattleshipsMove, BattleshipsState> {
+
+    override fun encodeMove(move: BattleshipsMove): Map<String, Any> = mapOf(
+        "gameState.battleships.moves" to FieldValue.arrayUnion(move.position),
+        "gameState.battleships.currentTurn" to move.playerUid
+    )
+
+    override fun decodeState(snapshot: Map<String, Any?>): BattleshipsState {
+        val gameData = snapshot["gameState"] as? Map<*, *>
+        val bsData = gameData?.get("battleships") as? Map<*, *> ?: emptyMap<String, Any>()
+        return BattleshipsState(
+            currentTurn = bsData["currentTurn"] as? String ?: "",
+            moves = bsData["moves"] as? List<String> ?: emptyList(),
+            gameResult = (bsData["gameResult"] as? Map<*, *>)?.let {
+                GameResult(
+                    winner = it["winner"] as? String ?: "",
+                    loser = it["loser"] as? String ?: "",
+                    reason = it["reason"] as? String ?: ""
+                )
+            }
+        )
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+org.gradle.configuration-cache=true


### PR DESCRIPTION
 New Features
In-game settings menu:
Added a settings icon that opens a menu with options to:

Surrender the match

Leave the game

Game end dialog:
After a player surrenders, both players now see a game-over dialog with:

The correct winning player name (not just UID)

Rematch and Leave Game buttons

Live rematch vote count (e.g. “1/2 voted”)

 Fixes and Improvements
 Correct winner/loser detection:
The opponent of the surrendering player is now correctly set as the winner.

Name display over UID:
Player names are shown instead of UIDs for currentTurn and winner.

 Rematch logic stabilized:
Fixed the rematch votes bouncing between 0/2 and 1/2. Game resets only once all players vote.

 Room joining + game start:
Game state (gameState) is now correctly initialized on start, preventing crashes.

 Firestore-safe UID usage:
All updates and writes use proper null-safe UID handling to prevent runtime exceptions.

 Testing Steps
Host a Battleships game from one device and join from another.

Press Surrender — confirm correct player wins.

Both players press Rematch — game resets and reinitializes without crashing.

Current turn and winner names are always player names (not raw UIDs).

Try pressing “Leave Game” — player is returned to the lobby/main menu and room is cleaned up.

Firebase Rules Confirmed
Firebase rules tested with anonymous authentication enabled.

All reads/writes operate within correct security scope.

 Affects
BattleshipsScreen.kt

LobbyService.kt

HostLobbyScreen.kt

Firebase structure: rematchVotes, gameState, players